### PR TITLE
Use DataSource in DB test script

### DIFF
--- a/backend/scripts/test-db.js
+++ b/backend/scripts/test-db.js
@@ -1,35 +1,36 @@
-const { createConnection } = require('typeorm');
+const { DataSource } = require('typeorm');
 
 async function testConnection() {
+  const dataSource = new DataSource({
+    type: 'mssql',
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT) || 1433,
+    username: process.env.DB_USER || 'sa',
+    password: process.env.DB_PASSWORD || 'FotekCRM2025!',
+    database: 'master',
+    options: {
+      encrypt: false,
+      trustServerCertificate: true,
+    },
+  });
+
   try {
     console.log('Database bağlantısı test ediliyor...');
-    
-    const connection = await createConnection({
-      type: 'mssql',
-      host: process.env.DB_HOST || 'localhost',
-      port: parseInt(process.env.DB_PORT) || 1433,
-      username: process.env.DB_USER || 'sa',
-      password: process.env.DB_PASSWORD || 'FotekCRM2025!',
-      database: 'master',
-      options: {
-        encrypt: false,
-        trustServerCertificate: true,
-      },
-    });
 
+    await dataSource.initialize();
     console.log('✅ Database bağlantısı başarılı!');
-    
+
     // Test user tablosu oluştur
-    await connection.query(`
+    await dataSource.query(`
       IF NOT EXISTS (SELECT name FROM sys.databases WHERE name = 'fotek_crm')
       BEGIN
         CREATE DATABASE fotek_crm;
       END
     `);
-    
+
     console.log('✅ fotek_crm database oluşturuldu/kontrol edildi');
-    
-    await connection.close();
+
+    await dataSource.destroy();
     console.log('✅ Database bağlantısı kapatıldı');
     
   } catch (error) {


### PR DESCRIPTION
## Summary
- refactor test-db script to use `DataSource`
- drop deprecated `createConnection` import

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684426559d7483249299ddca44de59db