### PR TITLE
Add env example and remove hardcoded secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DB_PASSWORD=your_db_password
+JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -36,12 +36,18 @@ Fotek CRM projesinin Minimum Viable Product (MVP) versiyonudur. Bu proje atomic 
    cd FotekCRM
    ```
 
-2. **Docker Compose ile servisleri başlatın:**
+2. **.env dosyasını oluşturun:**
+   ```bash
+   cp .env.example .env
+   # .env içindeki DB_PASSWORD ve JWT_SECRET değerlerini güncelleyin
+   ```
+
+3. **Docker Compose ile servisleri başlatın:**
    ```bash
    docker compose up --build
    ```
 
-3. **Servislerin durumunu kontrol edin:**
+4. **Servislerin durumunu kontrol edin:**
    - Frontend: http://localhost:80
    - API Health: http://localhost:3000/api/health
    - Database: localhost:1433
@@ -72,7 +78,7 @@ Fotek CRM projesinin Minimum Viable Product (MVP) versiyonudur. Bu proje atomic 
 
 3. **Database Bağlantısı:**
    ```bash
-   docker exec -it fotek_db /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'FotekCRM2025!'
+   docker exec -it fotek_db /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "$DB_PASSWORD"
    ```
 
 4. **Container Durumları:**

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,7 +26,7 @@ import { StockTransaction } from './entities/stock-transaction.entity';
       host: process.env.DB_HOST || 'db',
       port: parseInt(process.env.DB_PORT || '1433', 10),
       username: process.env.DB_USER || 'sa',
-      password: process.env.DB_PASSWORD || 'FotekCRM2025!',
+      password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME || 'master',
       entities: [User, Company, Contact, Product, ProductVariant, VariantAttribute, Order, OrderLine, StockTransaction],
       synchronize: true, // Only for development

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -14,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET || 'fotek-jwt-secret-key-2025',
+      secretOrKey: process.env.JWT_SECRET,
     });
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: fotek_db
     environment:
       ACCEPT_EULA: Y
-      SA_PASSWORD: FotekCRM2025!
+      SA_PASSWORD: ${DB_PASSWORD}
       MSSQL_PID: Express
     ports:
       - "1433:1433"
@@ -32,8 +32,8 @@ services:
       DB_PORT: 1433
       DB_NAME: master
       DB_USER: sa
-      DB_PASSWORD: FotekCRM2025!
-      JWT_SECRET: fotek-jwt-secret-key-2025
+      DB_PASSWORD: ${DB_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- add `.env.example` with required variables
- load DB credentials and JWT secret from env in `docker-compose.yml`
- rely solely on env variables in backend for DB password and JWT secret
- document creating `.env` in README

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: services not ready)*

------
https://chatgpt.com/codex/tasks/task_e_68442dbce1788324b716b7a04e5741b9