### PR TITLE
Remove unused lint script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,6 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
## Summary
- delete the `lint` script from `backend/package.json` because ESLint config is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684694df0598832492d613db4bf8597d